### PR TITLE
Add y12mff: double-precision iterative refinement with extended-precision residuals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           }
 
   build-and-test:
-    name: ${{ matrix.os }} / gfortran-${{ matrix.gcc }}
+    name: ${{ matrix.os }} / gfortran-${{ matrix.gcc }}${{ matrix.suffix }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -44,6 +44,12 @@ jobs:
         include:
           - os: ubuntu-latest
             gcc: 14
+          # Exercise the double-double fallback path of y12mff even though
+          # gfortran has quad precision.
+          - os: ubuntu-latest
+            gcc: 14
+            cmake_args: -DY12M_FORCE_DOUBLE_DOUBLE=ON
+            suffix: " (double-double)"
           - os: macos-latest
             gcc: 14
 
@@ -51,7 +57,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Configure
-        run: cmake -B build -DCMAKE_Fortran_COMPILER=gfortran-${{ matrix.gcc }}
+        run: cmake -B build -DCMAKE_Fortran_COMPILER=gfortran-${{ matrix.gcc }} ${{ matrix.cmake_args }}
 
       - name: Build
         run: cmake --build build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,16 @@ jobs:
           - os: ubuntu-latest
             gcc: 14
           # Exercise the double-double fallback path of y12mff even though
-          # gfortran has quad precision.
+          # gfortran has quad precision, with both TwoProd variants
+          # (default Dekker splitting, and the IEEE_FMA intrinsic).
           - os: ubuntu-latest
             gcc: 14
             cmake_args: -DY12M_FORCE_DOUBLE_DOUBLE=ON
             suffix: " (double-double)"
+          - os: ubuntu-latest
+            gcc: 14
+            cmake_args: -DY12M_FORCE_DOUBLE_DOUBLE=ON -DY12M_USE_IEEE_FMA=ON
+            suffix: " (double-double, ieee_fma)"
           - os: macos-latest
             gcc: 14
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,10 +50,13 @@ authorship.
   files directly: change the corresponding `.fpp` template, regenerate with
   `make -C templates` (requires `pip install fypp`), and commit the template
   together with the regenerated source.  CI fails if the two diverge.  Only
-  `y12mfe.f` (iterative refinement, single precision only) is maintained by
-  hand.
+  the iterative-refinement pair is maintained by hand: `y12mfe.f` (single
+  precision, fixed-form) and `src/y12mff.F90` (double precision, free-form;
+  excluded from the template pattern because its residual accumulator —
+  quad precision or double-double — cannot be expressed as a simple kind
+  substitution).
 - **Prefer module wrappers over changing legacy entry points.** Put modern
-  interface improvements in `src/y12m.f90` or helper modules; only edit a
+  interface improvements in `src/y12m.F90` or helper modules; only edit a
   legacy routine when the bug genuinely lives there.
 - **Keep single- and double-precision support aligned.** If a new helper,
   test, or interface is meant to be generic, add both `sp` and `dp` variants

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,11 +7,64 @@ project(y12m
 
 option(BUILD_EXAMPLES "Build the example programs" ON)
 option(WITH_NIST_MMIO "Build the Matrix Market driver (y12m_mm)" OFF)
+option(Y12M_FORCE_DOUBLE_DOUBLE
+    "Force double-double residual accumulation in y12mff even when the compiler supports quad precision" OFF)
 
 if(WITH_NIST_MMIO)
     include(cmake/FetchMMIO.cmake)
 endif()
 
+# ---------------------------------------------------------------------------
+# Residual accumulator for y12mff (double precision iterative refinement).
+#
+# y12mff accumulates residuals in higher than double precision: native quad
+# (selected_real_kind(33)) when the compiler provides it, otherwise a
+# double-double compensated accumulation built on IEEE_FMA.  Detect the
+# capabilities here and fix the strategy at configure time via the
+# Y12M_ACCUM_QUAD / Y12M_ACCUM_DD preprocessor macros (see src/y12mff.F90).
+# ---------------------------------------------------------------------------
+include(CheckFortranSourceCompiles)
+
+check_fortran_source_compiles("
+program conftest
+integer, parameter :: qp = selected_real_kind(33)
+real(qp) :: t
+t = 1.0_qp
+end program conftest
+" Y12M_HAVE_QUAD SRC_EXT F90)
+
+if(Y12M_HAVE_QUAD)
+    message(STATUS "Fortran compiler supports quad precision (selected_real_kind(33)): yes")
+else()
+    message(STATUS "Fortran compiler supports quad precision (selected_real_kind(33)): no")
+endif()
+
+if(Y12M_FORCE_DOUBLE_DOUBLE OR NOT Y12M_HAVE_QUAD)
+    check_fortran_source_compiles("
+program conftest
+use, intrinsic :: ieee_arithmetic, only: ieee_fma
+real(kind(1.0d0)) :: t
+t = ieee_fma(1.0d0, 1.0d0, 1.0d0)
+end program conftest
+" Y12M_HAVE_IEEE_FMA SRC_EXT F90)
+    if(NOT Y12M_HAVE_IEEE_FMA)
+        message(FATAL_ERROR
+            "y12mff needs the double-double residual accumulator "
+            "(quad precision unavailable or Y12M_FORCE_DOUBLE_DOUBLE=ON), "
+            "which requires the Fortran 2018 IEEE_FMA intrinsic. "
+            "Use a compiler that provides either quad precision or IEEE_FMA "
+            "(e.g. gfortran >= 13).")
+    endif()
+    set(Y12M_ACCUM_MACRO Y12M_ACCUM_DD)
+    if(Y12M_FORCE_DOUBLE_DOUBLE)
+        message(STATUS "y12mff residual accumulator: double-double (forced by Y12M_FORCE_DOUBLE_DOUBLE)")
+    else()
+        message(STATUS "y12mff residual accumulator: double-double (quad precision not available)")
+    endif()
+else()
+    set(Y12M_ACCUM_MACRO Y12M_ACCUM_QUAD)
+    message(STATUS "y12mff residual accumulator: quad precision (selected_real_kind(33))")
+endif()
 
 # Collect all legacy fixed-form Fortran sources.
 file(GLOB LEGACY_SOURCES "${CMAKE_SOURCE_DIR}/src/legacy/*.f")
@@ -19,7 +72,38 @@ file(GLOB LEGACY_SOURCES "${CMAKE_SOURCE_DIR}/src/legacy/*.f")
 # Build a static library from the legacy routines plus the Fortran module.
 # These sources are pre-existing; no extra diagnostic flags are applied.
 add_library(y12m_legacy STATIC ${LEGACY_SOURCES}
-    "${CMAKE_SOURCE_DIR}/src/y12m.f90")
+    "${CMAKE_SOURCE_DIR}/src/y12m.F90"
+    "${CMAKE_SOURCE_DIR}/src/y12mff.F90")
+
+# The accumulator selection must be identical in y12mff.F90 (the algorithm)
+# and y12m.F90 (the y12mff_has_quad / y12mff_accum_kind constants), so the
+# macro is applied to the whole target.
+target_compile_definitions(y12m_legacy PRIVATE ${Y12M_ACCUM_MACRO})
+
+# The double-double compensation terms in y12mff.F90 are algebraically zero;
+# value-unsafe floating point modes (-ffast-math, -Ofast, ifx's default
+# -fp-model=fast) are licensed to eliminate them, silently degrading the
+# accumulation to plain double precision.  Pin value-safe semantics for this
+# one file regardless of the global flags.
+if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+    set(Y12M_VALUE_SAFE_FLAGS -fno-unsafe-math-optimizations)
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "LLVMFlang|Flang|Clang")
+    set(Y12M_VALUE_SAFE_FLAGS -fno-fast-math)
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
+    if(WIN32)
+        set(Y12M_VALUE_SAFE_FLAGS /fp:precise)
+    else()
+        set(Y12M_VALUE_SAFE_FLAGS -fp-model=precise)
+    endif()
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "NVHPC|PGI")
+    set(Y12M_VALUE_SAFE_FLAGS -Kieee)
+else()
+    set(Y12M_VALUE_SAFE_FLAGS "")
+endif()
+if(Y12M_VALUE_SAFE_FLAGS)
+    set_source_files_properties("${CMAKE_SOURCE_DIR}/src/y12mff.F90"
+        PROPERTIES COMPILE_OPTIONS "${Y12M_VALUE_SAFE_FLAGS}")
+endif()
 
 # Place generated .mod files in a dedicated directory and expose it to
 # any target that links against this library.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,64 +7,15 @@ project(y12m
 
 option(BUILD_EXAMPLES "Build the example programs" ON)
 option(WITH_NIST_MMIO "Build the Matrix Market driver (y12m_mm)" OFF)
-option(Y12M_FORCE_DOUBLE_DOUBLE
-    "Force double-double residual accumulation in y12mff even when the compiler supports quad precision" OFF)
 
 if(WITH_NIST_MMIO)
     include(cmake/FetchMMIO.cmake)
 endif()
 
-# ---------------------------------------------------------------------------
-# Residual accumulator for y12mff (double precision iterative refinement).
-#
-# y12mff accumulates residuals in higher than double precision: native quad
-# (selected_real_kind(33)) when the compiler provides it, otherwise a
-# double-double compensated accumulation built on IEEE_FMA.  Detect the
-# capabilities here and fix the strategy at configure time via the
-# Y12M_ACCUM_QUAD / Y12M_ACCUM_DD preprocessor macros (see src/y12mff.F90).
-# ---------------------------------------------------------------------------
-include(CheckFortranSourceCompiles)
-
-check_fortran_source_compiles("
-program conftest
-integer, parameter :: qp = selected_real_kind(33)
-real(qp) :: t
-t = 1.0_qp
-end program conftest
-" Y12M_HAVE_QUAD SRC_EXT F90)
-
-if(Y12M_HAVE_QUAD)
-    message(STATUS "Fortran compiler supports quad precision (selected_real_kind(33)): yes")
-else()
-    message(STATUS "Fortran compiler supports quad precision (selected_real_kind(33)): no")
-endif()
-
-if(Y12M_FORCE_DOUBLE_DOUBLE OR NOT Y12M_HAVE_QUAD)
-    check_fortran_source_compiles("
-program conftest
-use, intrinsic :: ieee_arithmetic, only: ieee_fma
-real(kind(1.0d0)) :: t
-t = ieee_fma(1.0d0, 1.0d0, 1.0d0)
-end program conftest
-" Y12M_HAVE_IEEE_FMA SRC_EXT F90)
-    if(NOT Y12M_HAVE_IEEE_FMA)
-        message(FATAL_ERROR
-            "y12mff needs the double-double residual accumulator "
-            "(quad precision unavailable or Y12M_FORCE_DOUBLE_DOUBLE=ON), "
-            "which requires the Fortran 2018 IEEE_FMA intrinsic. "
-            "Use a compiler that provides either quad precision or IEEE_FMA "
-            "(e.g. gfortran >= 13).")
-    endif()
-    set(Y12M_ACCUM_MACRO Y12M_ACCUM_DD)
-    if(Y12M_FORCE_DOUBLE_DOUBLE)
-        message(STATUS "y12mff residual accumulator: double-double (forced by Y12M_FORCE_DOUBLE_DOUBLE)")
-    else()
-        message(STATUS "y12mff residual accumulator: double-double (quad precision not available)")
-    endif()
-else()
-    set(Y12M_ACCUM_MACRO Y12M_ACCUM_QUAD)
-    message(STATUS "y12mff residual accumulator: quad precision (selected_real_kind(33))")
-endif()
+# Residual accumulator for y12mff (quad precision or double-double); sets
+# Y12MFF_COMPILE_DEFINITIONS and Y12MFF_COMPILE_OPTIONS and prints the
+# selection.  Options: Y12M_FORCE_DOUBLE_DOUBLE, Y12M_USE_IEEE_FMA.
+include(cmake/Y12mffAccumulator.cmake)
 
 # Collect all legacy fixed-form Fortran sources.
 file(GLOB LEGACY_SOURCES "${CMAKE_SOURCE_DIR}/src/legacy/*.f")
@@ -76,33 +27,13 @@ add_library(y12m_legacy STATIC ${LEGACY_SOURCES}
     "${CMAKE_SOURCE_DIR}/src/y12mff.F90")
 
 # The accumulator selection must be identical in y12mff.F90 (the algorithm)
-# and y12m.F90 (the y12mff_has_quad / y12mff_accum_kind constants), so the
-# macro is applied to the whole target.
-target_compile_definitions(y12m_legacy PRIVATE ${Y12M_ACCUM_MACRO})
-
-# The double-double compensation terms in y12mff.F90 are algebraically zero;
-# value-unsafe floating point modes (-ffast-math, -Ofast, ifx's default
-# -fp-model=fast) are licensed to eliminate them, silently degrading the
-# accumulation to plain double precision.  Pin value-safe semantics for this
-# one file regardless of the global flags.
-if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
-    set(Y12M_VALUE_SAFE_FLAGS -fno-unsafe-math-optimizations)
-elseif(CMAKE_Fortran_COMPILER_ID MATCHES "LLVMFlang|Flang|Clang")
-    set(Y12M_VALUE_SAFE_FLAGS -fno-fast-math)
-elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
-    if(WIN32)
-        set(Y12M_VALUE_SAFE_FLAGS /fp:precise)
-    else()
-        set(Y12M_VALUE_SAFE_FLAGS -fp-model=precise)
-    endif()
-elseif(CMAKE_Fortran_COMPILER_ID MATCHES "NVHPC|PGI")
-    set(Y12M_VALUE_SAFE_FLAGS -Kieee)
-else()
-    set(Y12M_VALUE_SAFE_FLAGS "")
-endif()
-if(Y12M_VALUE_SAFE_FLAGS)
+# and y12m.F90 (the y12mff_uses_quad / y12mff_accumulator_kind constants),
+# so the macros are applied to the whole target.  The IEEE-compliance flags
+# only concern the double-double arithmetic in y12mff.F90.
+target_compile_definitions(y12m_legacy PRIVATE ${Y12MFF_COMPILE_DEFINITIONS})
+if(Y12MFF_COMPILE_OPTIONS)
     set_source_files_properties("${CMAKE_SOURCE_DIR}/src/y12mff.F90"
-        PROPERTIES COMPILE_OPTIONS "${Y12M_VALUE_SAFE_FLAGS}")
+        PROPERTIES COMPILE_OPTIONS "${Y12MFF_COMPILE_OPTIONS}")
 endif()
 
 # Place generated .mod files in a dedicated directory and expose it to

--- a/README.md
+++ b/README.md
@@ -112,16 +112,19 @@ The library (without tests and examples) can also be built with
 At configure time CMake detects whether the Fortran compiler supports quad
 precision (`selected_real_kind(33)`) and reports which residual accumulator
 the double-precision iterative-refinement routine `Y12MFF` will use: native
-quad precision, or a double-double emulation built on `IEEE_FMA` (requires a
-Fortran 2018 compiler, e.g. gfortran ≥ 13).  Pass
-`-DY12M_FORCE_DOUBLE_DOUBLE=ON` to force the double-double path even when
-quad precision is available — useful for bit-reproducible results across
-compilers and for testing the fallback.  The module constants
-`y12mff_has_quad` and `y12mff_accum_kind` expose the compiled-in choice to
-user code.  Note that the double-double arithmetic requires value-safe
-floating-point semantics; the CMake build compiles `src/y12mff.F90` with the
-appropriate compiler flag (e.g. `-fno-unsafe-math-optimizations` for
-gfortran) so that a global `-ffast-math`/`-Ofast` cannot break it.
+quad precision, or a double-double emulation (Dekker's product splitting by
+default; pass `-DY12M_USE_IEEE_FMA=ON` to use the Fortran 2018 `IEEE_FMA`
+intrinsic instead, worthwhile only when the compiler inlines it to a
+hardware instruction).  Pass `-DY12M_FORCE_DOUBLE_DOUBLE=ON` to force the
+double-double path even when quad precision is available — useful for
+bit-reproducible results across compilers and for testing the fallback.
+The module constants `y12mff_uses_quad` and `y12mff_accumulator_kind`
+expose the compiled-in choice to user code.  Note that the double-double
+arithmetic requires IEEE-compliant evaluation; the CMake build compiles
+`src/y12mff.F90` with the appropriate flags (for gfortran:
+`-fno-unsafe-math-optimizations -ffp-contract=off`) so that a global
+`-ffast-math`/`-Ofast` — or FMA contraction on fma-capable hardware —
+cannot silently break it (see `cmake/Y12mffAccumulator.cmake`).
 
 > **Note for contributors:** most fixed-form sources in `src/legacy/` are
 > generated from the [Fypp](https://github.com/aradi/fypp) templates in

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ reordering.
   `Y12MC` / `Y12MD`) lets you reuse an LU factorization or a sparsity
   ordering across multiple solves (see [docs/multiple_rhs.md](docs/multiple_rhs.md)).
 - **Iterative refinement.** `Y12MF` provides built-in iterative refinement for
-  extra accuracy.
+  extra accuracy.  Residuals are accumulated in extended precision: double
+  precision in `Y12MFE`, and quad precision (or a double-double software
+  emulation when the compiler lacks quad support) in `Y12MFF`.
 
 ### Limitations
 
@@ -106,6 +108,20 @@ example programs.  The `y12m` Fortran module (`.mod` file) is placed in
 
 The library (without tests and examples) can also be built with
 [fpm](https://fpm.fortran-lang.org): `fpm build`.
+
+At configure time CMake detects whether the Fortran compiler supports quad
+precision (`selected_real_kind(33)`) and reports which residual accumulator
+the double-precision iterative-refinement routine `Y12MFF` will use: native
+quad precision, or a double-double emulation built on `IEEE_FMA` (requires a
+Fortran 2018 compiler, e.g. gfortran ≥ 13).  Pass
+`-DY12M_FORCE_DOUBLE_DOUBLE=ON` to force the double-double path even when
+quad precision is available — useful for bit-reproducible results across
+compilers and for testing the fallback.  The module constants
+`y12mff_has_quad` and `y12mff_accum_kind` expose the compiled-in choice to
+user code.  Note that the double-double arithmetic requires value-safe
+floating-point semantics; the CMake build compiles `src/y12mff.F90` with the
+appropriate compiler flag (e.g. `-fno-unsafe-math-optimizations` for
+gfortran) so that a global `-ffast-math`/`-Ofast` cannot break it.
 
 > **Note for contributors:** most fixed-form sources in `src/legacy/` are
 > generated from the [Fypp](https://github.com/aradi/fypp) templates in

--- a/cmake/Y12mffAccumulator.cmake
+++ b/cmake/Y12mffAccumulator.cmake
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Assisted-by: Claude Code:claude-fable-5
+#
+# Residual accumulator selection for y12mff (double precision iterative
+# refinement, src/y12mff.F90).
+#
+# y12mff accumulates residuals in higher than double precision: native quad
+# (selected_real_kind(33)) when the compiler provides it, otherwise a
+# double-double compensated accumulation.  This script detects the compiler
+# capabilities, honours the user options, and reports the outcome.  It sets:
+#
+#   Y12MFF_COMPILE_DEFINITIONS  preprocessor macros for the y12m_legacy
+#                               target (Y12M_ACCUM_QUAD or Y12M_ACCUM_DD,
+#                               plus Y12M_USE_IEEE_FMA when requested)
+#   Y12MFF_COMPILE_OPTIONS      per-source flags for src/y12mff.F90 that pin
+#                               IEEE-compliant evaluation of the
+#                               double-double arithmetic (empty when the
+#                               quad path is selected)
+#
+# The double-double compensation terms are algebraically zero, so
+# value-unsafe modes (-ffast-math/-Ofast, ifx's default -fp-model=fast) are
+# licensed to eliminate them, silently degrading the accumulator to plain
+# double.  In addition, the default Dekker product splitting is broken by
+# FMA contraction (gfortran/flang default -ffp-contract=fast on fma-capable
+# hardware): fusing t - a with t = splitter*a skips exactly the rounding
+# the split depends on.  Hence value-safe flags whenever the double-double
+# path is compiled, and contraction disabled unless IEEE_FMA is used.
+
+option(Y12M_FORCE_DOUBLE_DOUBLE
+    "Force double-double residual accumulation in y12mff even when the compiler supports quad precision" OFF)
+option(Y12M_USE_IEEE_FMA
+    "Use the Fortran 2018 IEEE_FMA intrinsic for the double-double product splitting in y12mff (default: Dekker's algorithm). Worthwhile only when the compiler inlines it to a hardware instruction." OFF)
+
+include(CheckFortranSourceCompiles)
+
+check_fortran_source_compiles("
+program conftest
+integer, parameter :: qp = selected_real_kind(33)
+real(qp) :: t
+t = 1.0_qp
+end program conftest
+" Y12M_HAVE_QUAD SRC_EXT F90)
+
+if(Y12M_HAVE_QUAD)
+    message(STATUS "Fortran compiler supports quad precision (selected_real_kind(33)): yes")
+else()
+    message(STATUS "Fortran compiler supports quad precision (selected_real_kind(33)): no")
+endif()
+
+set(Y12MFF_COMPILE_DEFINITIONS "")
+set(Y12MFF_COMPILE_OPTIONS "")
+
+if(Y12M_USE_IEEE_FMA)
+    check_fortran_source_compiles("
+program conftest
+use, intrinsic :: ieee_arithmetic, only: ieee_fma
+real(kind(1.0d0)) :: t
+t = ieee_fma(1.0d0, 1.0d0, 1.0d0)
+end program conftest
+" Y12M_HAVE_IEEE_FMA SRC_EXT F90)
+    if(NOT Y12M_HAVE_IEEE_FMA)
+        message(FATAL_ERROR
+            "Y12M_USE_IEEE_FMA=ON but the Fortran compiler does not support "
+            "the Fortran 2018 IEEE_FMA intrinsic (gfortran needs version 13 "
+            "or newer).  Turn the option off to use Dekker's algorithm.")
+    endif()
+    list(APPEND Y12MFF_COMPILE_DEFINITIONS Y12M_USE_IEEE_FMA)
+endif()
+
+if(Y12M_FORCE_DOUBLE_DOUBLE OR NOT Y12M_HAVE_QUAD)
+    list(APPEND Y12MFF_COMPILE_DEFINITIONS Y12M_ACCUM_DD)
+    if(Y12M_USE_IEEE_FMA)
+        set(_y12mff_twoprod "IEEE_FMA")
+    else()
+        set(_y12mff_twoprod "Dekker splitting")
+    endif()
+    if(Y12M_FORCE_DOUBLE_DOUBLE)
+        message(STATUS "y12mff residual accumulator: double-double via ${_y12mff_twoprod} (forced by Y12M_FORCE_DOUBLE_DOUBLE)")
+    else()
+        message(STATUS "y12mff residual accumulator: double-double via ${_y12mff_twoprod} (quad precision not available)")
+    endif()
+    unset(_y12mff_twoprod)
+
+    # Value-safe evaluation for the compensated arithmetic.
+    if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+        list(APPEND Y12MFF_COMPILE_OPTIONS -fno-unsafe-math-optimizations)
+    elseif(CMAKE_Fortran_COMPILER_ID MATCHES "LLVMFlang|Flang|Clang")
+        list(APPEND Y12MFF_COMPILE_OPTIONS -fno-fast-math)
+    elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
+        if(WIN32)
+            list(APPEND Y12MFF_COMPILE_OPTIONS /fp:precise)
+        else()
+            list(APPEND Y12MFF_COMPILE_OPTIONS -fp-model=precise)
+        endif()
+    elseif(CMAKE_Fortran_COMPILER_ID MATCHES "NVHPC|PGI")
+        list(APPEND Y12MFF_COMPILE_OPTIONS -Kieee)
+    endif()
+
+    # No FMA contraction for the Dekker splitting (the IEEE_FMA variant is
+    # immune, so contraction may stay enabled there).
+    if(NOT Y12M_USE_IEEE_FMA)
+        if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU|LLVMFlang|Clang")
+            list(APPEND Y12MFF_COMPILE_OPTIONS -ffp-contract=off)
+        elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
+            if(WIN32)
+                list(APPEND Y12MFF_COMPILE_OPTIONS /Qfma-)
+            else()
+                list(APPEND Y12MFF_COMPILE_OPTIONS -no-fma)
+            endif()
+        elseif(CMAKE_Fortran_COMPILER_ID MATCHES "NVHPC|PGI")
+            list(APPEND Y12MFF_COMPILE_OPTIONS -Mnofma)
+        endif()
+    endif()
+else()
+    list(APPEND Y12MFF_COMPILE_DEFINITIONS Y12M_ACCUM_QUAD)
+    message(STATUS "y12mff residual accumulator: quad precision (selected_real_kind(33))")
+endif()

--- a/docs/API.md
+++ b/docs/API.md
@@ -345,18 +345,27 @@ Black-box driver with **iterative refinement**.  Solves **Ax = b** and
 improves the solution by computing successive corrections
 **d(k) = QU⁻¹L⁻¹Pr(k-1)** where **r(k-1) = b − Ax(k-1)**.
 
-> Only a **single-precision** version (`Y12MFE`) is available.  Inner products
-> in the refinement loop are accumulated in double precision and rounded back to
-> single precision.
+> Residuals must be accumulated in higher than working precision for the
+> refinement to be meaningful.  `Y12MFE` (single precision) accumulates in
+> double precision and rounds back to single.  `Y12MFF` (double precision)
+> accumulates in **quad precision** (`selected_real_kind(33)`) when the
+> compiler provides it, and otherwise falls back to a **double-double**
+> compensated accumulation (TwoProd via `IEEE_FMA` + TwoSum).  The strategy
+> is fixed at compile time; the module constants `y12mff_has_quad`
+> (logical) and `y12mff_accum_kind` (integer kind value) report which one
+> was built in.  The CMake option `-DY12M_FORCE_DOUBLE_DOUBLE=ON` forces the
+> double-double path even when quad precision is available (useful for
+> reproducibility across compilers and for testing the fallback); the
+> configure step prints which accumulator was selected.
 
 ```fortran
-subroutine y12mfe(n, a, snr, nn, rnr, nn1, a1, sn, nz, ha, iha, b, b1, x, y, aflag, iflag, ifail)
-  integer, intent(in)    :: n, nn, nn1, nz, iha
-  real,    intent(inout) :: a(nn), aflag(11)
-  integer, intent(inout) :: snr(nn), rnr(nn1), ha(iha,13), sn(nz), iflag(12)
-  real,    intent(inout) :: a1(nz), b(n)
-  real,    intent(out)   :: b1(n), x(n), y(n)
-  integer, intent(out)   :: ifail
+subroutine y12mf[e|f](n, a, snr, nn, rnr, nn1, a1, sn, nz, ha, iha, b, b1, x, y, aflag, iflag, ifail)
+  integer,            intent(in)    :: n, nn, nn1, nz, iha
+  real(kind=[sp,dp]), intent(inout) :: a(nn), aflag(11)
+  integer,            intent(inout) :: snr(nn), rnr(nn1), ha(iha,13), sn(nz), iflag(12)
+  real(kind=[sp,dp]), intent(inout) :: a1(nz), b(n)
+  real(kind=[sp,dp]), intent(out)   :: b1(n), x(n), y(n)
+  integer,            intent(out)   :: ifail
 ```
 
 **Arguments:**

--- a/docs/API.md
+++ b/docs/API.md
@@ -350,9 +350,12 @@ improves the solution by computing successive corrections
 > double precision and rounds back to single.  `Y12MFF` (double precision)
 > accumulates in **quad precision** (`selected_real_kind(33)`) when the
 > compiler provides it, and otherwise falls back to a **double-double**
-> compensated accumulation (TwoProd + TwoSum; Dekker's splitting by
-> default, or the Fortran 2018 `IEEE_FMA` intrinsic with
-> `-DY12M_USE_IEEE_FMA=ON`).  The strategy is fixed at compile time; the
+> compensated accumulation — the *Dot2* algorithm of
+> [Ogita, Rump & Oishi (2005)](https://doi.org/10.1137/030601818), with the
+> exact products formed by
+> [Dekker's (1971)](https://doi.org/10.1007/BF01397083) splitting technique
+> by default, or by the Fortran 2018 `IEEE_FMA` intrinsic with
+> `-DY12M_USE_IEEE_FMA=ON`.  The strategy is fixed at compile time; the
 > module constants `y12mff_uses_quad` (logical) and
 > `y12mff_accumulator_kind` (integer kind value) report which one was
 > built in.  The CMake option `-DY12M_FORCE_DOUBLE_DOUBLE=ON` forces the

--- a/docs/API.md
+++ b/docs/API.md
@@ -350,10 +350,12 @@ improves the solution by computing successive corrections
 > double precision and rounds back to single.  `Y12MFF` (double precision)
 > accumulates in **quad precision** (`selected_real_kind(33)`) when the
 > compiler provides it, and otherwise falls back to a **double-double**
-> compensated accumulation (TwoProd via `IEEE_FMA` + TwoSum).  The strategy
-> is fixed at compile time; the module constants `y12mff_has_quad`
-> (logical) and `y12mff_accum_kind` (integer kind value) report which one
-> was built in.  The CMake option `-DY12M_FORCE_DOUBLE_DOUBLE=ON` forces the
+> compensated accumulation (TwoProd + TwoSum; Dekker's splitting by
+> default, or the Fortran 2018 `IEEE_FMA` intrinsic with
+> `-DY12M_USE_IEEE_FMA=ON`).  The strategy is fixed at compile time; the
+> module constants `y12mff_uses_quad` (logical) and
+> `y12mff_accumulator_kind` (integer kind value) report which one was
+> built in.  The CMake option `-DY12M_FORCE_DOUBLE_DOUBLE=ON` forces the
 > double-double path even when quad precision is available (useful for
 > reproducibility across compilers and for testing the fallback); the
 > configure step prints which accumulator was selected.

--- a/include/y12m.h
+++ b/include/y12m.h
@@ -111,6 +111,14 @@ extern void FNAME(y12mfe)(int *n,
                           float *b, float *b1, float *x, float *y,
                           float *aflag, int *iflag, int *ifail);
 
+extern void FNAME(y12mff)(int *n,
+                          double *a, int *snr, int *nn,
+                          int *rnr, int *nn1,
+                          double *a1, int *sn, int *nz,
+                          int *ha, int *iha,
+                          double *b, double *b1, double *x, double *y,
+                          double *aflag, int *iflag, int *ifail);
+
 extern void FNAME(y12mge)(int *n, int *nn,
                           float *a, int *snr,
                           float *w, float *pivot,
@@ -243,6 +251,20 @@ static inline int y12mfe(int n,
 {
    int ifail;
    FNAME(y12mfe)(&n, a, snr, &nn, rnr, &nn1, a1, sn, &nz, ha, &iha,
+                 b, b1, x, y, aflag, iflag, &ifail);
+   return ifail;
+}
+
+static inline int y12mff(int n,
+                         double a[], int snr[], int nn,
+                         int rnr[], int nn1,
+                         double a1[], int sn[], int nz,
+                         int ha[], int iha,
+                         double b[], double b1[], double x[], double y[],
+                         double aflag[], int iflag[])
+{
+   int ifail;
+   FNAME(y12mff)(&n, a, snr, &nn, rnr, &nn1, a1, sn, &nz, ha, &iha,
                  b, b1, x, y, aflag, iflag, &ifail);
    return ifail;
 }

--- a/src/y12m.F90
+++ b/src/y12m.F90
@@ -33,21 +33,23 @@ module y12m
   ! -------------------------------------------------------------------------
 
   !> True when y12mff accumulates residuals in native quad precision;
-  !> false when it uses the double-double emulation.
+  !> false when it uses the double-double emulation.  Note "uses", not
+  !> "has": with the double-double path forced at build time this is false
+  !> even on a compiler that supports quad precision.
 #if defined(Y12M_ACCUM_DD)
-  logical, parameter, public :: y12mff_has_quad = .false.
+  logical, parameter, public :: y12mff_uses_quad = .false.
 #elif defined(Y12M_ACCUM_QUAD)
-  logical, parameter, public :: y12mff_has_quad = .true.
+  logical, parameter, public :: y12mff_uses_quad = .true.
 #else
-  logical, parameter, public :: y12mff_has_quad = selected_real_kind(33) > 0
+  logical, parameter, public :: y12mff_uses_quad = selected_real_kind(33) > 0
 #endif
 
   !> Kind parameter of the y12mff residual accumulator.  Equal to
-  !> selected_real_kind(33) when y12mff_has_quad is true; otherwise equal to
-  !> kind(1.0d0), the working kind on which the double-double arithmetic is
-  !> built.
-  integer, parameter, public :: y12mff_accum_kind = &
-      merge(selected_real_kind(33), kind(1.0d0), y12mff_has_quad)
+  !> selected_real_kind(33) when y12mff_uses_quad is true; otherwise equal
+  !> to kind(1.0d0), the working kind on which the double-double arithmetic
+  !> is built.
+  integer, parameter, public :: y12mff_accumulator_kind = &
+      merge(selected_real_kind(33), kind(1.0d0), y12mff_uses_quad)
 
 
   !> Solve a sparse system of linear equations Ax=b by Gaussian elimination.

--- a/src/y12m.F90
+++ b/src/y12m.F90
@@ -23,6 +23,32 @@ module y12m
   ! Error string
   public :: y12m_get_error_msg
 
+  ! -------------------------------------------------------------------------
+  ! Residual accumulation strategy of y12mff (double precision iterative
+  ! refinement).  y12mff accumulates the residuals b - A*x in higher than
+  ! working precision: native quad when available, otherwise a double-double
+  ! (compensated) accumulation.  The selection is fixed at compile time and
+  ! must match src/y12mff.F90, so the same Y12M_ACCUM_QUAD / Y12M_ACCUM_DD
+  ! macros drive both files (the CMake build defines exactly one of them).
+  ! -------------------------------------------------------------------------
+
+  !> True when y12mff accumulates residuals in native quad precision;
+  !> false when it uses the double-double emulation.
+#if defined(Y12M_ACCUM_DD)
+  logical, parameter, public :: y12mff_has_quad = .false.
+#elif defined(Y12M_ACCUM_QUAD)
+  logical, parameter, public :: y12mff_has_quad = .true.
+#else
+  logical, parameter, public :: y12mff_has_quad = selected_real_kind(33) > 0
+#endif
+
+  !> Kind parameter of the y12mff residual accumulator.  Equal to
+  !> selected_real_kind(33) when y12mff_has_quad is true; otherwise equal to
+  !> kind(1.0d0), the working kind on which the double-double arithmetic is
+  !> built.
+  integer, parameter, public :: y12mff_accum_kind = &
+      merge(selected_real_kind(33), kind(1.0d0), y12mff_has_quad)
+
 
   !> Solve a sparse system of linear equations Ax=b by Gaussian elimination.
   !>
@@ -161,6 +187,24 @@ module y12m
       real, intent(inout) :: x(n)
       real, intent(inout) :: y(n)
       real, intent(inout) :: aflag(11)
+      integer, intent(inout) :: iflag(12)
+      integer, intent(out) :: ifail
+    end subroutine
+    subroutine y12mff(n, a, snr, nn, rnr, nn1, a1, sn, nz, &
+        ha, iha, b, b1, x, y, aflag, iflag, ifail)
+      implicit none
+      integer, intent(in) :: n, nn, nn1, nz, iha
+      double precision, intent(inout) :: a(nn)
+      integer, intent(inout) :: snr(nn)
+      integer, intent(inout) :: rnr(nn1)
+      double precision, intent(inout) :: a1(nz)
+      integer, intent(inout) :: sn(nz)
+      integer, intent(inout) :: ha(iha,13)
+      double precision, intent(inout) :: b(n)
+      double precision, intent(inout) :: b1(n)
+      double precision, intent(inout) :: x(n)
+      double precision, intent(inout) :: y(n)
+      double precision, intent(inout) :: aflag(11)
       integer, intent(inout) :: iflag(12)
       integer, intent(out) :: ifail
     end subroutine

--- a/src/y12mff.F90
+++ b/src/y12mff.F90
@@ -1,0 +1,276 @@
+! SPDX-License-Identifier: GPL-2.0-only
+! Assisted-by: Claude Code:claude-fable-5
+!
+! y12mff.F90 - Double precision version of y12mfe.
+!
+! Solves a sparse system Ax = b by Gaussian elimination with subsequent
+! iterative refinement.  The algorithm and the control flow follow the
+! single precision routine y12mfe (src/legacy/y12mfe.f) exactly; only the
+! working precision and the residual accumulation differ.
+!
+! y12mfe accumulates the residuals r = b - A*x in double precision and
+! rounds back to single.  For a double precision working type the
+! accumulator must be wider than double.  Two strategies are provided:
+!
+!   * quad precision, selected_real_kind(33), when the compiler offers it;
+!   * a double-double compensated accumulation (TwoProd via IEEE_FMA plus
+!     TwoSum, error terms carried in a low-order word) which yields a
+!     residual as accurate as if it were computed in twice double
+!     precision (Ogita/Rump/Oishi "Dot2").
+!
+! The strategy is fixed at compile time:
+!
+!   Y12M_ACCUM_QUAD  defined: compile the quad path only.
+!   Y12M_ACCUM_DD    defined: compile the double-double path only.
+!   neither          defined: compile both paths and pick quad when
+!                             selected_real_kind(33) > 0 (the unused path
+!                             is dead code behind a constant condition).
+!                             This mode requires IEEE_FMA (Fortran 2018).
+!
+! The CMake build always defines exactly one of the two macros, driven by
+! a configure-time capability check and the Y12M_FORCE_DOUBLE_DOUBLE
+! option; the self-detecting mode serves build systems that do not
+! preprocess capability checks (e.g. fpm).
+!
+! WARNING: the double-double path is destroyed by value-unsafe floating
+! point optimisation (-ffast-math, -Ofast, ifx's default -fp-model=fast,
+! nvfortran without -Kieee).  The compensation terms are algebraically
+! zero, so a compiler licensed to reassociate eliminates them and the
+! accumulation silently degrades to plain double precision.  The CMake
+! build pins value-safe flags for this file; keep that in mind when
+! compiling it by other means.
+!
+#if defined(Y12M_ACCUM_QUAD) && defined(Y12M_ACCUM_DD)
+#error "Y12M_ACCUM_QUAD and Y12M_ACCUM_DD are mutually exclusive"
+#endif
+subroutine y12mff(n, a, snr, nn, rnr, nn1, a1, sn, nz, &
+      ha, iha, b, b1, x, y, aflag, iflag, ifail)
+#ifndef Y12M_ACCUM_QUAD
+   use, intrinsic :: ieee_arithmetic, only: ieee_fma
+#endif
+   implicit none
+
+   integer, parameter :: dp = kind(1.0d0)
+#ifdef Y12M_ACCUM_DD
+   logical, parameter :: use_quad = .false.
+#else
+   integer, parameter :: qp = selected_real_kind(33)
+#ifdef Y12M_ACCUM_QUAD
+   logical, parameter :: use_quad = .true.
+#else
+   logical, parameter :: use_quad = qp > 0
+#endif
+   ! When quad is unavailable hp falls back to dp; the quad path is then
+   ! dead code behind the constant use_quad and is never executed.
+   integer, parameter :: hp = merge(qp, dp, use_quad)
+#endif
+
+   integer, intent(in) :: n, nn, nn1, nz, iha
+   real(dp), intent(inout) :: a(nn)
+   integer, intent(inout) :: snr(nn)
+   integer, intent(inout) :: rnr(nn1)
+   real(dp), intent(inout) :: a1(nz)
+   integer, intent(inout) :: sn(nz)
+   integer, intent(inout) :: ha(iha,13)
+   real(dp), intent(inout) :: b(n)
+   real(dp), intent(inout) :: b1(n)
+   real(dp), intent(inout) :: x(n)
+   real(dp), intent(inout) :: y(n)
+   real(dp), intent(inout) :: aflag(11)
+   integer, intent(inout) :: iflag(12)
+   integer, intent(out) :: ifail
+
+   external y12mbf, y12mcf, y12mdf
+
+   real(dp) :: d, dd, dres, gt1, gt2, xx, xm, dcor, er
+   integer :: nres, state, kit, it
+   integer :: i, j, l1, l2
+
+   ! Store the non-zero elements, their column numbers, information about
+   ! row starts, information about row ends, and the right-hand side.
+   ifail = 0
+   nres = 0
+   dres = 0.0_dp
+   state = iflag(5)
+   kit = 1
+   it = iflag(11)
+   if (state == 1) ifail = 10
+   if (it < 2) ifail = 23
+   if (ifail /= 0) go to 160
+
+   do i = 1, n
+      b1(i) = b(i)
+   end do
+
+   if (state == 3) go to 70
+
+   call y12mbf(n, nz, a, snr, nn, rnr, nn1, ha, iha, aflag, iflag, ifail)
+   if (ifail /= 0) go to 160
+
+   do i = 1, nz
+      sn(i) = snr(i)
+      a1(i) = a(i)
+   end do
+
+   do i = 1, n
+      ha(i,12) = ha(i,1)
+      ha(i,13) = ha(i,3)
+   end do
+
+   if (aflag(2) >= 0.0_dp) go to 60
+
+   gt1 = aflag(6)
+   do i = 1, n
+      l1 = ha(i,1)
+      l2 = ha(i,3)
+      gt2 = 0.0_dp
+      do j = l1, l2
+         d = abs(a(j))
+         if (gt2 < d) gt2 = d
+      end do
+      if (gt2 < gt1) gt1 = gt2
+   end do
+   aflag(2) = -gt1*aflag(2)
+
+   ! Find the first solution.
+60 call y12mcf(n, nz, a, snr, nn, rnr, nn1, y, b, ha, iha, aflag, iflag, ifail)
+   if (ifail /= 0) go to 160
+
+70 call y12mdf(n, a, nn, b, y, snr, ha, iha, iflag, ifail)
+   if (ifail /= 0) go to 160
+
+   ! Prepare the data in order to begin the iterations.
+   dd = 0.0_dp
+   do i = 1, n
+      x(i) = b(i)
+      xx = abs(b(i))
+      if (dd < xx) dd = xx
+   end do
+   xm = dd
+   if (dd == 0.0_dp) go to 160
+
+   ! Begin to iterate.
+90 d = dd
+   dres = 0.0_dp
+   do i = 1, n
+      l1 = ha(i,12)
+      l2 = ha(i,13)
+#if defined(Y12M_ACCUM_DD)
+      er = residual_dd(b1(i), l1, l2)
+#elif defined(Y12M_ACCUM_QUAD)
+      er = residual_quad(b1(i), l1, l2)
+#else
+      if (use_quad) then
+         er = residual_quad(b1(i), l1, l2)
+      else
+         er = residual_dd(b1(i), l1, l2)
+      end if
+#endif
+      ! Store residuals rounded to working (double) precision.
+      b(i) = er
+      xx = abs(er)
+      if (dres < xx) dres = xx
+   end do
+   if (dres == 0.0_dp) go to 160
+   if (nres == 1) go to 150
+   if (dres > 1.0e4_dp*xm) go to 150
+
+   kit = kit + 1
+   iflag(5) = 3
+   call y12mdf(n, a, nn, b, y, snr, ha, iha, iflag, ifail)
+   if (ifail /= 0) go to 160
+
+   ! Compute the uniform norm of the current correction vector.
+   dd = 0.0_dp
+   do i = 1, n
+      xx = abs(b(i))
+      if (dd < xx) dd = xx
+   end do
+   if (dd == 0.0_dp) go to 160
+
+   ! Check the convergence criterion.
+   if (dd > d .and. kit > 2) go to 160
+
+   ! Calculate an improved solution.
+   dcor = dd
+   xm = 0.0_dp
+   do i = 1, n
+      x(i) = x(i) + b(i)
+      xx = abs(x(i))
+      if (xx > xm) xm = xx
+   end do
+
+   ! Check the stopping criteria.
+   if (10.0_dp + dd/xm == 10.0_dp) go to 140
+   if (kit < it) go to 90
+
+   ! End of the iterations.
+140 nres = 1
+   go to 90
+
+150 dd = abs(dd)
+
+160 iflag(5) = state
+   iflag(12) = kit
+   aflag(9) = dd
+   aflag(10) = dres
+   aflag(11) = xm
+   return
+
+contains
+
+#ifndef Y12M_ACCUM_DD
+   !> Row residual b1i - sum_j a1(j)*x(sn(j)), j = l1..l2, accumulated in
+   !> quad precision and rounded once to double.
+   pure function residual_quad(b1i, l1, l2) result(er)
+      real(dp), intent(in) :: b1i
+      integer, intent(in) :: l1, l2
+      real(dp) :: er
+      real(hp) :: er_hp
+      integer :: j, l3
+      er_hp = real(b1i, hp)
+      do j = l1, l2
+         l3 = sn(j)
+         er_hp = er_hp - real(a1(j), hp)*real(x(l3), hp)
+      end do
+      er = real(er_hp, dp)
+   end function residual_quad
+#endif
+
+#ifndef Y12M_ACCUM_QUAD
+   !> Row residual b1i - sum_j a1(j)*x(sn(j)), j = l1..l2, accumulated in
+   !> double-double arithmetic (compensated dot product, Ogita/Rump/Oishi
+   !> "Dot2").  Each product is split exactly into p + pe with IEEE_FMA
+   !> (TwoProd); the subtraction from the high word er_hi is made exact
+   !> with a TwoSum, and both error terms are collected in the low word
+   !> er_lo.  The result is as accurate as a residual computed in twice
+   !> double precision, using only *, +, - and one fma per element.
+   !>
+   !> Correctness relies on IEEE-compliant evaluation: the compensation
+   !> terms are algebraically zero and must not be simplified away (see
+   !> the file header note on -ffast-math).
+   pure function residual_dd(b1i, l1, l2) result(er)
+      real(dp), intent(in) :: b1i
+      integer, intent(in) :: l1, l2
+      real(dp) :: er
+      real(dp) :: er_hi, er_lo, p, pe, s, z, e
+      integer :: j, l3
+      er_hi = b1i
+      er_lo = 0.0_dp
+      do j = l1, l2
+         l3 = sn(j)
+         ! TwoProd: p + pe = a1(j)*x(l3) exactly
+         p = a1(j)*x(l3)
+         pe = ieee_fma(a1(j), x(l3), -p)
+         ! TwoSum: s + e = er_hi - p exactly
+         s = er_hi - p
+         z = s - er_hi
+         e = (er_hi - (s - z)) - (p + z)
+         er_hi = s
+         er_lo = er_lo + (e - pe)
+      end do
+      er = er_hi + er_lo
+   end function residual_dd
+#endif
+
+end subroutine y12mff

--- a/src/y12mff.F90
+++ b/src/y12mff.F90
@@ -56,6 +56,20 @@
 ! variant); when compiling the double-double path by other means, apply
 ! the equivalent flags yourself.
 !
+! References:
+!
+!   T. J. Dekker, "A floating-point technique for extending the available
+!   precision", Numerische Mathematik 18, 224-242 (1971).
+!   https://doi.org/10.1007/BF01397083
+!   (exact product of two floating-point numbers via factor splitting;
+!   the default TwoProd in residual_dd)
+!
+!   T. Ogita, S. M. Rump and S. Oishi, "Accurate sum and dot product",
+!   SIAM Journal on Scientific Computing 26(6), 1955-1988 (2005).
+!   https://doi.org/10.1137/030601818
+!   (the Dot2 compensated dot product that residual_dd follows, built
+!   from TwoProd and the branch-free TwoSum, which is due to Knuth)
+!
 #if defined(Y12M_ACCUM_QUAD) && defined(Y12M_ACCUM_DD)
 #error "Y12M_ACCUM_QUAD and Y12M_ACCUM_DD are mutually exclusive"
 #endif
@@ -262,12 +276,13 @@ contains
 
 #ifndef Y12M_ACCUM_QUAD
    !> Row residual b1i - sum_j a1(j)*x(sn(j)), j = l1..l2, accumulated in
-   !> double-double arithmetic (compensated dot product, Ogita/Rump/Oishi
-   !> "Dot2").  Each product is split exactly into p + pe (TwoProd); the
-   !> subtraction from the high word er_hi is made exact with a TwoSum,
-   !> and both error terms are collected in the low word er_lo.  The
-   !> result is as accurate as a residual computed in twice double
-   !> precision.
+   !> double-double arithmetic: the Dot2 compensated dot product of Ogita,
+   !> Rump and Oishi (2005); see the references in the file header.  Each
+   !> product is split exactly into p + pe (TwoProd, by default Dekker's
+   !> 1971 technique); the subtraction from the high word er_hi is made
+   !> exact with a TwoSum, and both error terms are collected in the low
+   !> word er_lo.  The result is as accurate as a residual computed in
+   !> twice double precision.
    !>
    !> Correctness relies on IEEE-compliant evaluation; see the file
    !> header note on -ffast-math and -ffp-contract.

--- a/src/y12mff.F90
+++ b/src/y12mff.F90
@@ -4,19 +4,21 @@
 ! y12mff.F90 - Double precision version of y12mfe.
 !
 ! Solves a sparse system Ax = b by Gaussian elimination with subsequent
-! iterative refinement.  The algorithm and the control flow follow the
-! single precision routine y12mfe (src/legacy/y12mfe.f) exactly; only the
-! working precision and the residual accumulation differ.
+! iterative refinement.  The algorithm is that of the single precision
+! routine y12mfe (src/legacy/y12mfe.f); the goto-based control flow of the
+! original is expressed here with a named block, a bounded refinement loop,
+! and early exits, with identical semantics (same stopping tests, same
+! IFLAG/AFLAG outputs).
 !
 ! y12mfe accumulates the residuals r = b - A*x in double precision and
 ! rounds back to single.  For a double precision working type the
 ! accumulator must be wider than double.  Two strategies are provided:
 !
 !   * quad precision, selected_real_kind(33), when the compiler offers it;
-!   * a double-double compensated accumulation (TwoProd via IEEE_FMA plus
-!     TwoSum, error terms carried in a low-order word) which yields a
-!     residual as accurate as if it were computed in twice double
-!     precision (Ogita/Rump/Oishi "Dot2").
+!   * a double-double compensated accumulation (TwoProd + TwoSum, error
+!     terms carried in a low-order word) which yields a residual as
+!     accurate as if it were computed in twice double precision
+!     (Ogita/Rump/Oishi "Dot2").
 !
 ! The strategy is fixed at compile time:
 !
@@ -25,27 +27,41 @@
 !   neither          defined: compile both paths and pick quad when
 !                             selected_real_kind(33) > 0 (the unused path
 !                             is dead code behind a constant condition).
-!                             This mode requires IEEE_FMA (Fortran 2018).
 !
-! The CMake build always defines exactly one of the two macros, driven by
-! a configure-time capability check and the Y12M_FORCE_DOUBLE_DOUBLE
-! option; the self-detecting mode serves build systems that do not
-! preprocess capability checks (e.g. fpm).
+! The exact product splitting (TwoProd) in the double-double path uses
+! Dekker's algorithm by default: portable Fortran, no library calls.
+! Define Y12M_USE_IEEE_FMA to use the Fortran 2018 IEEE_FMA intrinsic
+! instead (one fma per element instead of Dekker's 17 flops; worthwhile
+! only when the compiler inlines it to a hardware instruction rather than
+! dispatching to a runtime call).
 !
-! WARNING: the double-double path is destroyed by value-unsafe floating
-! point optimisation (-ffast-math, -Ofast, ifx's default -fp-model=fast,
-! nvfortran without -Kieee).  The compensation terms are algebraically
-! zero, so a compiler licensed to reassociate eliminates them and the
-! accumulation silently degrades to plain double precision.  The CMake
-! build pins value-safe flags for this file; keep that in mind when
-! compiling it by other means.
+! The CMake build selects the macros from a configure-time capability
+! check and the Y12M_FORCE_DOUBLE_DOUBLE / Y12M_USE_IEEE_FMA options; the
+! self-detecting mode serves build systems that do not preprocess
+! capability checks (e.g. fpm).
+!
+! WARNING: the double-double path relies on IEEE-compliant evaluation.
+!
+!   * Value-unsafe optimisation (-ffast-math, -Ofast, ifx's default
+!     -fp-model=fast, nvfortran without -Kieee) eliminates the
+!     compensation terms, which are algebraically zero, and the
+!     accumulation silently degrades to plain double precision.
+!   * FMA contraction (gfortran/flang default -ffp-contract=fast on
+!     hardware with fma instructions) breaks Dekker's splitting: fusing
+!     t - aj with t = splitter*aj skips exactly the rounding the split
+!     depends on.  The IEEE_FMA variant is immune to contraction.
+!
+! The CMake build pins the required flags on this file (e.g. for gfortran
+! -fno-unsafe-math-optimizations, plus -ffp-contract=off for the Dekker
+! variant); when compiling the double-double path by other means, apply
+! the equivalent flags yourself.
 !
 #if defined(Y12M_ACCUM_QUAD) && defined(Y12M_ACCUM_DD)
 #error "Y12M_ACCUM_QUAD and Y12M_ACCUM_DD are mutually exclusive"
 #endif
 subroutine y12mff(n, a, snr, nn, rnr, nn1, a1, sn, nz, &
       ha, iha, b, b1, x, y, aflag, iflag, ifail)
-#ifndef Y12M_ACCUM_QUAD
+#if !defined(Y12M_ACCUM_QUAD) && defined(Y12M_USE_IEEE_FMA)
    use, intrinsic :: ieee_arithmetic, only: ieee_fma
 #endif
    implicit none
@@ -82,140 +98,147 @@ subroutine y12mff(n, a, snr, nn, rnr, nn1, a1, sn, nz, &
 
    external y12mbf, y12mcf, y12mdf
 
-   real(dp) :: d, dd, dres, gt1, gt2, xx, xm, dcor, er
+   real(dp) :: d, dd, dres, gt1, gt2, xx, xm, er
    integer :: nres, state, kit, it
-   integer :: i, j, l1, l2
+   integer :: i, j, l1, l2, pass
 
-   ! Store the non-zero elements, their column numbers, information about
-   ! row starts, information about row ends, and the right-hand side.
    ifail = 0
    nres = 0
+   dd = 0.0_dp
    dres = 0.0_dp
+   xm = 0.0_dp
    state = iflag(5)
    kit = 1
    it = iflag(11)
-   if (state == 1) ifail = 10
-   if (it < 2) ifail = 23
-   if (ifail /= 0) go to 160
 
-   do i = 1, n
-      b1(i) = b(i)
-   end do
+   solve: block
 
-   if (state == 3) go to 70
+      if (state == 1) ifail = 10
+      if (it < 2) ifail = 23
+      if (ifail /= 0) exit solve
 
-   call y12mbf(n, nz, a, snr, nn, rnr, nn1, ha, iha, aflag, iflag, ifail)
-   if (ifail /= 0) go to 160
+      ! Save the right-hand side; b is overwritten by the solves.
+      b1(1:n) = b(1:n)
 
-   do i = 1, nz
-      sn(i) = snr(i)
-      a1(i) = a(i)
-   end do
+      ! state == 3 reuses an existing factorization: skip straight to the
+      ! back-substitution for the new right-hand side.
+      if (state /= 3) then
 
-   do i = 1, n
-      ha(i,12) = ha(i,1)
-      ha(i,13) = ha(i,3)
-   end do
+         call y12mbf(n, nz, a, snr, nn, rnr, nn1, ha, iha, aflag, iflag, ifail)
+         if (ifail /= 0) exit solve
 
-   if (aflag(2) >= 0.0_dp) go to 60
+         ! Keep a row-ordered copy of the original matrix (and its row
+         ! start/end positions) for the residual computation: y12mcf
+         ! overwrites a/snr with the factors.
+         a1(1:nz) = a(1:nz)
+         sn(1:nz) = snr(1:nz)
+         do i = 1, n
+            ha(i,12) = ha(i,1)
+            ha(i,13) = ha(i,3)
+         end do
 
-   gt1 = aflag(6)
-   do i = 1, n
-      l1 = ha(i,1)
-      l2 = ha(i,3)
-      gt2 = 0.0_dp
-      do j = l1, l2
-         d = abs(a(j))
-         if (gt2 < d) gt2 = d
-      end do
-      if (gt2 < gt1) gt1 = gt2
-   end do
-   aflag(2) = -gt1*aflag(2)
+         ! A negative aflag(2) requests a relative drop tolerance: scale it
+         ! by the smallest row maximum (but never above aflag(6) = max|A|).
+         if (aflag(2) < 0.0_dp) then
+            gt1 = aflag(6)
+            do i = 1, n
+               l1 = ha(i,1)
+               l2 = ha(i,3)
+               gt2 = 0.0_dp
+               do j = l1, l2
+                  d = abs(a(j))
+                  if (gt2 < d) gt2 = d
+               end do
+               if (gt2 < gt1) gt1 = gt2
+            end do
+            aflag(2) = -gt1*aflag(2)
+         end if
 
-   ! Find the first solution.
-60 call y12mcf(n, nz, a, snr, nn, rnr, nn1, y, b, ha, iha, aflag, iflag, ifail)
-   if (ifail /= 0) go to 160
+         ! Factorize and find the first solution.
+         call y12mcf(n, nz, a, snr, nn, rnr, nn1, y, b, ha, iha, &
+             aflag, iflag, ifail)
+         if (ifail /= 0) exit solve
 
-70 call y12mdf(n, a, nn, b, y, snr, ha, iha, iflag, ifail)
-   if (ifail /= 0) go to 160
-
-   ! Prepare the data in order to begin the iterations.
-   dd = 0.0_dp
-   do i = 1, n
-      x(i) = b(i)
-      xx = abs(b(i))
-      if (dd < xx) dd = xx
-   end do
-   xm = dd
-   if (dd == 0.0_dp) go to 160
-
-   ! Begin to iterate.
-90 d = dd
-   dres = 0.0_dp
-   do i = 1, n
-      l1 = ha(i,12)
-      l2 = ha(i,13)
-#if defined(Y12M_ACCUM_DD)
-      er = residual_dd(b1(i), l1, l2)
-#elif defined(Y12M_ACCUM_QUAD)
-      er = residual_quad(b1(i), l1, l2)
-#else
-      if (use_quad) then
-         er = residual_quad(b1(i), l1, l2)
-      else
-         er = residual_dd(b1(i), l1, l2)
       end if
+
+      call y12mdf(n, a, nn, b, y, snr, ha, iha, iflag, ifail)
+      if (ifail /= 0) exit solve
+
+      ! Prepare the data in order to begin the iterations.
+      x(1:n) = b(1:n)
+      dd = maxval(abs(b(1:n)))
+      xm = dd
+      if (dd == 0.0_dp) exit solve
+
+      ! Refinement.  Pass k computes the residual r = b1 - A*x(k-1); unless
+      ! a stopping test fires it then performs the kit-th solve for the
+      ! correction d(k) and updates x.  When nres is set (correction
+      ! negligible, or iteration budget reached) one final residual-only
+      ! pass runs so that the reported dres and the residual left in b
+      ! belong to the final x; "it" therefore bounds the number of passes.
+      ! kit counts the solves (initial solution included) and cannot serve
+      ! as the loop index: the final pass does not advance it, and it is
+      ! reported in iflag(12).
+      refine: do pass = 1, it
+
+         d = dd
+         dres = 0.0_dp
+         do i = 1, n
+            l1 = ha(i,12)
+            l2 = ha(i,13)
+#if defined(Y12M_ACCUM_DD)
+            er = residual_dd(b1(i), l1, l2)
+#elif defined(Y12M_ACCUM_QUAD)
+            er = residual_quad(b1(i), l1, l2)
+#else
+            if (use_quad) then
+               er = residual_quad(b1(i), l1, l2)
+            else
+               er = residual_dd(b1(i), l1, l2)
+            end if
 #endif
-      ! Store residuals rounded to working (double) precision.
-      b(i) = er
-      xx = abs(er)
-      if (dres < xx) dres = xx
-   end do
-   if (dres == 0.0_dp) go to 160
-   if (nres == 1) go to 150
-   if (dres > 1.0e4_dp*xm) go to 150
+            ! Store residuals rounded to working (double) precision.
+            b(i) = er
+            xx = abs(er)
+            if (dres < xx) dres = xx
+         end do
+         if (dres == 0.0_dp) exit refine
 
-   kit = kit + 1
-   iflag(5) = 3
-   call y12mdf(n, a, nn, b, y, snr, ha, iha, iflag, ifail)
-   if (ifail /= 0) go to 160
+         ! Final residual-only pass done, or residual blow-up.
+         if (nres == 1 .or. dres > 1.0e4_dp*xm) then
+            dd = abs(dd)
+            exit refine
+         end if
 
-   ! Compute the uniform norm of the current correction vector.
-   dd = 0.0_dp
-   do i = 1, n
-      xx = abs(b(i))
-      if (dd < xx) dd = xx
-   end do
-   if (dd == 0.0_dp) go to 160
+         ! Solve for the correction (in b) and measure it.
+         kit = kit + 1
+         iflag(5) = 3
+         call y12mdf(n, a, nn, b, y, snr, ha, iha, iflag, ifail)
+         if (ifail /= 0) exit refine
+         dd = maxval(abs(b(1:n)))
+         if (dd == 0.0_dp) exit refine
 
-   ! Check the convergence criterion.
-   if (dd > d .and. kit > 2) go to 160
+         ! Divergence: the corrections grow after the second solve.
+         if (dd > d .and. kit > 2) exit refine
 
-   ! Calculate an improved solution.
-   dcor = dd
-   xm = 0.0_dp
-   do i = 1, n
-      x(i) = x(i) + b(i)
-      xx = abs(x(i))
-      if (xx > xm) xm = xx
-   end do
+         ! Calculate an improved solution.
+         x(1:n) = x(1:n) + b(1:n)
+         xm = maxval(abs(x(1:n)))
 
-   ! Check the stopping criteria.
-   if (10.0_dp + dd/xm == 10.0_dp) go to 140
-   if (kit < it) go to 90
+         ! Stopping criteria: negligible correction, or no iterations left.
+         ! Either way one final residual-only pass follows.
+         if (10.0_dp + dd/xm == 10.0_dp .or. kit >= it) nres = 1
 
-   ! End of the iterations.
-140 nres = 1
-   go to 90
+      end do refine
 
-150 dd = abs(dd)
+   end block solve
 
-160 iflag(5) = state
+   ! Restore the caller's flags and report the diagnostics.
+   iflag(5) = state
    iflag(12) = kit
    aflag(9) = dd
    aflag(10) = dres
    aflag(11) = xm
-   return
 
 contains
 
@@ -240,28 +263,47 @@ contains
 #ifndef Y12M_ACCUM_QUAD
    !> Row residual b1i - sum_j a1(j)*x(sn(j)), j = l1..l2, accumulated in
    !> double-double arithmetic (compensated dot product, Ogita/Rump/Oishi
-   !> "Dot2").  Each product is split exactly into p + pe with IEEE_FMA
-   !> (TwoProd); the subtraction from the high word er_hi is made exact
-   !> with a TwoSum, and both error terms are collected in the low word
-   !> er_lo.  The result is as accurate as a residual computed in twice
-   !> double precision, using only *, +, - and one fma per element.
+   !> "Dot2").  Each product is split exactly into p + pe (TwoProd); the
+   !> subtraction from the high word er_hi is made exact with a TwoSum,
+   !> and both error terms are collected in the low word er_lo.  The
+   !> result is as accurate as a residual computed in twice double
+   !> precision.
    !>
-   !> Correctness relies on IEEE-compliant evaluation: the compensation
-   !> terms are algebraically zero and must not be simplified away (see
-   !> the file header note on -ffast-math).
+   !> Correctness relies on IEEE-compliant evaluation; see the file
+   !> header note on -ffast-math and -ffp-contract.
    pure function residual_dd(b1i, l1, l2) result(er)
       real(dp), intent(in) :: b1i
       integer, intent(in) :: l1, l2
       real(dp) :: er
-      real(dp) :: er_hi, er_lo, p, pe, s, z, e
+#ifndef Y12M_USE_IEEE_FMA
+      real(dp), parameter :: splitter = 134217729.0_dp  ! 2**27 + 1
+      real(dp) :: t, a_hi, a_lo, x_hi, x_lo
+#endif
+      real(dp) :: er_hi, er_lo, aj, xj, p, pe, s, z, e
       integer :: j, l3
       er_hi = b1i
       er_lo = 0.0_dp
       do j = l1, l2
          l3 = sn(j)
-         ! TwoProd: p + pe = a1(j)*x(l3) exactly
-         p = a1(j)*x(l3)
-         pe = ieee_fma(a1(j), x(l3), -p)
+         aj = a1(j)
+         xj = x(l3)
+         ! TwoProd: p + pe = aj*xj exactly
+         p = aj*xj
+#ifdef Y12M_USE_IEEE_FMA
+         pe = ieee_fma(aj, xj, -p)
+#else
+         ! Dekker splitting: both factors are cut into 26-bit halves whose
+         ! four partial products are exact, recovering the rounding error
+         ! of p.  Overflows for |aj| or |xj| >= 2**996; residuals of such
+         ! magnitude are far outside the solver's working range.
+         t = splitter*aj
+         a_hi = t - (t - aj)
+         a_lo = aj - a_hi
+         t = splitter*xj
+         x_hi = t - (t - xj)
+         x_lo = xj - x_hi
+         pe = ((a_hi*x_hi - p) + a_hi*x_lo + a_lo*x_hi) + a_lo*x_lo
+#endif
          ! TwoSum: s + e = er_hi - p exactly
          s = er_hi - p
          z = s - er_hi

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,6 +15,7 @@ foreach(tname
     test_y12mb_mc_md_sp
     test_y12mb_mc_md_dp
     test_y12mf_sp
+    test_y12mf_dp
     test_y12mf_errors
     test_y12mg_mh
     test_y12ma_hilbert)

--- a/test/test_plan.md
+++ b/test/test_plan.md
@@ -25,7 +25,7 @@ Files with a `.f90` extension produce a single executable.
 | `test_y12mc_z_intent.F90` | `test_y12mc_z_intent_sp`, `test_y12mc_z_intent_dp` | y12mc | SP + DP | regression: `z` must be unchanged on success path, on early-error exit, and when passed as an integer literal |
 | `test_y12md_errors.F90` | `test_y12md_errors_sp`, `test_y12md_errors_dp` | y12mb + y12mc + y12md | SP + DP | error-path coverage (IFAIL=1); success with IFLAG(5)=1 and IFLAG(5)=2; multiple-RHS reuse (IFLAG(5)=3) on 6×6 reference matrix |
 | `test_y12mf_sp.f90` | `test_y12mf_sp` | y12mf | SP | tridiagonal n=3,5,7,10 |
-| `test_y12mf_dp.f90` | `test_y12mf_dp` | y12mf | DP | tridiagonal n=3,5,7,10, arrow n=6,10; reports/validates the `y12mff_has_quad` / `y12mff_accum_kind` accumulator constants |
+| `test_y12mf_dp.f90` | `test_y12mf_dp` | y12mf | DP | tridiagonal n=3,5,7,10, arrow n=6,10; reports/validates the `y12mff_uses_quad` / `y12mff_accumulator_kind` accumulator constants |
 | `test_y12mf_errors.f90` | `test_y12mf_errors` | y12mf | SP | 6×6 reference; error-path (IFAIL=10,23); output-parameter invariants (IFLAG(12), AFLAG(9–11), B, B1); LU-reuse (IFLAG(5)=3) |
 | `test_y12mg_mh.f90` | `test_y12mg_mh` | y12mg + y12mh | SP + DP | 1-norm of n=5 (SP) and n=10 (DP) tridiagonal; condition estimate after full y12mb→y12mc→y12md→y12mg sequence |
 | `test_y12ma_y12mf_bench_sp.f90` | `test_y12ma_y12mf_bench_sp` | y12ma + y12mf | SP | UMFPACK 5×5, Harwell-Boeing 4×4, Pardiso 8×8, Templates 6×6 |

--- a/test/test_plan.md
+++ b/test/test_plan.md
@@ -25,6 +25,7 @@ Files with a `.f90` extension produce a single executable.
 | `test_y12mc_z_intent.F90` | `test_y12mc_z_intent_sp`, `test_y12mc_z_intent_dp` | y12mc | SP + DP | regression: `z` must be unchanged on success path, on early-error exit, and when passed as an integer literal |
 | `test_y12md_errors.F90` | `test_y12md_errors_sp`, `test_y12md_errors_dp` | y12mb + y12mc + y12md | SP + DP | error-path coverage (IFAIL=1); success with IFLAG(5)=1 and IFLAG(5)=2; multiple-RHS reuse (IFLAG(5)=3) on 6×6 reference matrix |
 | `test_y12mf_sp.f90` | `test_y12mf_sp` | y12mf | SP | tridiagonal n=3,5,7,10 |
+| `test_y12mf_dp.f90` | `test_y12mf_dp` | y12mf | DP | tridiagonal n=3,5,7,10, arrow n=6,10; reports/validates the `y12mff_has_quad` / `y12mff_accum_kind` accumulator constants |
 | `test_y12mf_errors.f90` | `test_y12mf_errors` | y12mf | SP | 6×6 reference; error-path (IFAIL=10,23); output-parameter invariants (IFLAG(12), AFLAG(9–11), B, B1); LU-reuse (IFLAG(5)=3) |
 | `test_y12mg_mh.f90` | `test_y12mg_mh` | y12mg + y12mh | SP + DP | 1-norm of n=5 (SP) and n=10 (DP) tridiagonal; condition estimate after full y12mb→y12mc→y12md→y12mg sequence |
 | `test_y12ma_y12mf_bench_sp.f90` | `test_y12ma_y12mf_bench_sp` | y12ma + y12mf | SP | UMFPACK 5×5, Harwell-Boeing 4×4, Pardiso 8×8, Templates 6×6 |
@@ -35,13 +36,16 @@ Files with a `.f90` extension produce a single executable.
 
 ## 2. Coverage gaps
 
-### 2.1 Missing precision variant for y12mf
+### 2.1 Precision variants of y12mf *(partially resolved)*
 
-`y12mfe` (single precision) is the only iterative-refinement routine in
-`src/legacy/`.  No double-precision `y12mff` exists in the current source
-tree, so there is no DP variant to test.  If a double-precision IR routine
-is added in the future, tests analogous to `test_y12mf_sp.f90` should be
-created.
+`y12mff` (double precision, `src/y12mff.F90`) now complements `y12mfe` and
+is covered by `test_y12mf_dp.f90`.  Residuals are accumulated in quad
+precision or, when quad is unavailable (or `Y12M_FORCE_DOUBLE_DOUBLE=ON`),
+in double-double arithmetic.  Remaining gaps: the error paths and output
+invariants checked by `test_y12mf_errors.f90` are exercised in SP only, and
+CI builds only the default accumulator — a job with
+`-DY12M_FORCE_DOUBLE_DOUBLE=ON` would keep the fallback path tested on
+compilers that have quad precision.
 
 ### 2.2 C and C++ interfaces not tested
 

--- a/test/test_y12mf_dp.f90
+++ b/test/test_y12mf_dp.f90
@@ -7,8 +7,8 @@
 ! elimination with iterative refinement.  Residuals are accumulated in
 ! higher-than-double precision: native quad when available, otherwise a
 ! double-double compensated accumulation (see src/y12mff.F90).  The
-! accumulator actually compiled in is reported via the y12mff_has_quad and
-! y12mff_accum_kind module constants.
+! accumulator actually compiled in is reported via the y12mff_uses_quad
+! and y12mff_accumulator_kind module constants.
 !
 ! Systems solved (all with known solution x = [1,...,1]):
 !   tridiagonal (diag=3, off-diag=-1): n = 3, 5, 7, 10
@@ -17,12 +17,16 @@
 ! The factored form is stored with IFLAG(5)=2 (keep L factors) as required
 ! by y12mf.  The refined solution is returned in array x (not b).
 !
-! Pass criteria: consistent accumulator constants, and IFAIL=0 with
-! max|x_i-1| < 1e-13 for all systems.
+! Also checks the input-validation exits: IFLAG(5)=1 must give IFAIL=10 and
+! IFLAG(11)<2 must give IFAIL=23, with IFLAG(5) restored on return.
+!
+! Pass criteria: consistent accumulator constants, expected IFAIL on the
+! error paths, and IFAIL=0 with max|x_i-1| < 1e-13 for all systems.
 !
 program test_y12mf_dp
-   use y12m, only: y12mf, y12mff_has_quad, y12mff_accum_kind
-   use y12m_test_helpers, only: build_tridiag, build_arrow, check_solution
+   use y12m, only: y12mf, y12mff_uses_quad, y12mff_accumulator_kind
+   use y12m_test_helpers, only: build_tridiag, build_arrow, check_solution, &
+       check_ifail
    implicit none
 
    integer, parameter :: dp = kind(1.0d0)
@@ -39,18 +43,18 @@ program test_y12mf_dp
    nfail = 0
 
    ! Report and sanity-check the accumulator selected at compile time.
-   if (y12mff_has_quad) then
+   if (y12mff_uses_quad) then
       write(*,'(a,i0,a)') 'y12mff accumulator: quad precision (kind=', &
-          y12mff_accum_kind, ')'
-      if (y12mff_accum_kind /= selected_real_kind(33)) then
-         write(*,'(a)') 'FAIL y12mff_accum_kind inconsistent with quad selection'
+          y12mff_accumulator_kind, ')'
+      if (y12mff_accumulator_kind /= selected_real_kind(33)) then
+         write(*,'(a)') 'FAIL y12mff_accumulator_kind inconsistent with quad selection'
          nfail = nfail + 1
       end if
    else
       write(*,'(a,i0,a)') 'y12mff accumulator: double-double (kind=', &
-          y12mff_accum_kind, ')'
-      if (y12mff_accum_kind /= dp) then
-         write(*,'(a)') 'FAIL y12mff_accum_kind inconsistent with double-double selection'
+          y12mff_accumulator_kind, ')'
+      if (y12mff_accumulator_kind /= dp) then
+         write(*,'(a)') 'FAIL y12mff_accumulator_kind inconsistent with double-double selection'
          nfail = nfail + 1
       end if
    end if
@@ -64,6 +68,10 @@ program test_y12mf_dp
    ! Arrow systems: n = 6, 10
    call run_arrow(6)
    call run_arrow(10)
+
+   ! Input-validation exits (on a 5x5 tridiagonal system).
+   call run_error('y12mf_dp ifail=23 (it<2)', iflag5=2, iflag11=1, ifail_exp=23)
+   call run_error('y12mf_dp ifail=10 (iflag5=1)', iflag5=1, iflag11=10, ifail_exp=10)
 
    if (nfail /= 0) then
       write(*,'(i0,a)') nfail, ' test(s) FAILED'
@@ -128,5 +136,39 @@ contains
 
       call check_solution(label, n, x, ifail, TOL, nfail)
    end subroutine solve_and_check
+
+   !> Call y12mf with an invalid IFLAG setting and verify the expected
+   !> IFAIL and that IFLAG(5) is restored on return.
+   subroutine run_error(label, iflag5, iflag11, ifail_exp)
+      character(len=*), intent(in) :: label
+      integer, intent(in) :: iflag5, iflag11, ifail_exp
+
+      n = 5
+      call build_tridiag(n, NNP, NN1P, z, a, snr, rnr, b)
+      nn = NNP
+      nn1 = NN1P
+      iha = NMAX
+
+      aflag(1) = 16.0_dp
+      aflag(2) = 1.0e-12_dp
+      aflag(3) = 1.0e+16_dp
+      aflag(4) = 1.0e-12_dp
+
+      iflag(1) = 0
+      iflag(2) = 3
+      iflag(3) = 1
+      iflag(4) = 1
+      iflag(5) = iflag5
+      iflag(11) = iflag11
+
+      call y12mf(n, a, snr, nn, rnr, nn1, a1, sn, z, ha, iha, &
+          b, b1, x, y, aflag, iflag, ifail)
+
+      call check_ifail(label, ifail, ifail_exp, nfail)
+      if (iflag(5) /= iflag5) then
+         write(*,'(3a,i0)') 'FAIL ', label, ' iflag(5) not restored: ', iflag(5)
+         nfail = nfail + 1
+      end if
+   end subroutine run_error
 
 end program test_y12mf_dp

--- a/test/test_y12mf_dp.f90
+++ b/test/test_y12mf_dp.f90
@@ -1,0 +1,132 @@
+! SPDX-License-Identifier: GPL-2.0-only
+! Assisted-by: Claude Code:claude-fable-5
+!
+! test_y12mf_dp.f90 - Tests for y12mf (double-precision iterative refinement).
+!
+! This program tests y12mf (resolving to y12mff) which combines Gaussian
+! elimination with iterative refinement.  Residuals are accumulated in
+! higher-than-double precision: native quad when available, otherwise a
+! double-double compensated accumulation (see src/y12mff.F90).  The
+! accumulator actually compiled in is reported via the y12mff_has_quad and
+! y12mff_accum_kind module constants.
+!
+! Systems solved (all with known solution x = [1,...,1]):
+!   tridiagonal (diag=3, off-diag=-1): n = 3, 5, 7, 10
+!   arrow (full first row/col + diagonal): n = 6, 10
+!
+! The factored form is stored with IFLAG(5)=2 (keep L factors) as required
+! by y12mf.  The refined solution is returned in array x (not b).
+!
+! Pass criteria: consistent accumulator constants, and IFAIL=0 with
+! max|x_i-1| < 1e-13 for all systems.
+!
+program test_y12mf_dp
+   use y12m, only: y12mf, y12mff_has_quad, y12mff_accum_kind
+   use y12m_test_helpers, only: build_tridiag, build_arrow, check_solution
+   implicit none
+
+   integer, parameter :: dp = kind(1.0d0)
+   integer, parameter :: NMAX = 12
+   integer, parameter :: NNP = 400
+   integer, parameter :: NN1P = 400
+   real(dp), parameter :: TOL = 1.0e-13_dp
+
+   real(dp) :: a(NNP), a1(NNP), b(NMAX), b1(NMAX), x(NMAX), y(NMAX)
+   real(dp) :: aflag(11)
+   integer :: snr(NNP), sn(NNP), rnr(NN1P), ha(NMAX,13), iflag(12)
+   integer :: n, z, nn, nn1, iha, ifail, nfail
+
+   nfail = 0
+
+   ! Report and sanity-check the accumulator selected at compile time.
+   if (y12mff_has_quad) then
+      write(*,'(a,i0,a)') 'y12mff accumulator: quad precision (kind=', &
+          y12mff_accum_kind, ')'
+      if (y12mff_accum_kind /= selected_real_kind(33)) then
+         write(*,'(a)') 'FAIL y12mff_accum_kind inconsistent with quad selection'
+         nfail = nfail + 1
+      end if
+   else
+      write(*,'(a,i0,a)') 'y12mff accumulator: double-double (kind=', &
+          y12mff_accum_kind, ')'
+      if (y12mff_accum_kind /= dp) then
+         write(*,'(a)') 'FAIL y12mff_accum_kind inconsistent with double-double selection'
+         nfail = nfail + 1
+      end if
+   end if
+
+   ! Tridiagonal systems: n = 3, 5, 7, 10
+   call run_tridiag(3)
+   call run_tridiag(5)
+   call run_tridiag(7)
+   call run_tridiag(10)
+
+   ! Arrow systems: n = 6, 10
+   call run_arrow(6)
+   call run_arrow(10)
+
+   if (nfail /= 0) then
+      write(*,'(i0,a)') nfail, ' test(s) FAILED'
+      stop 1
+   end if
+   write(*,'(a)') 'All test_y12mf_dp tests PASSED'
+
+contains
+
+   subroutine run_tridiag(n_in)
+      integer, intent(in) :: n_in
+      character(len=30) :: label
+      n = n_in
+      write(label,'(a,i0,a)') 'y12mf_dp n=', n, ' tridiag'
+      call build_tridiag(n, NNP, NN1P, z, a, snr, rnr, b)
+      call solve_and_check(trim(label))
+   end subroutine run_tridiag
+
+   subroutine run_arrow(n_in)
+      integer, intent(in) :: n_in
+      character(len=30) :: label
+      n = n_in
+      write(label,'(a,i0,a)') 'y12mf_dp n=', n, ' arrow'
+      call build_arrow(n, NNP, NN1P, z, a, snr, rnr, b)
+      call solve_and_check(trim(label))
+   end subroutine run_arrow
+
+   !> Call y12mf on the COO system already loaded in a/snr/rnr/b and verify
+   !> the refined solution against the known solution x = [1,...,1].
+   subroutine solve_and_check(label)
+      character(len=*), intent(in) :: label
+      integer :: i
+
+      nn = NNP
+      nn1 = NN1P
+      iha = NMAX
+
+      ! Settings per the reference example (test2.f).
+      ! IFLAG(5)=2 keeps L factors as required by y12mf.
+      aflag(1) = 16.0_dp     ! stability factor
+      aflag(2) = 1.0e-12_dp  ! drop tolerance
+      aflag(3) = 1.0e+16_dp  ! max growth factor before abort
+      aflag(4) = 1.0e-12_dp  ! min pivot threshold
+
+      iflag(1) = 0
+      iflag(2) = 3
+      iflag(3) = 1
+      iflag(4) = 1   ! preserve structure info for iterative refinement
+      iflag(5) = 2   ! keep L factors (required by y12mf)
+      iflag(11) = 10 ! maximum number of refinement iterations
+
+      x(1:n) = 0.0_dp
+      y(1:n) = 0.0_dp
+      b1(1:n) = 0.0_dp
+      do i = 1, z
+         a1(i) = 0.0_dp
+         sn(i) = 0
+      end do
+
+      call y12mf(n, a, snr, nn, rnr, nn1, a1, sn, z, ha, iha, &
+          b, b1, x, y, aflag, iflag, ifail)
+
+      call check_solution(label, n, x, ifail, TOL, nfail)
+   end subroutine solve_and_check
+
+end program test_y12mf_dp


### PR DESCRIPTION
## Summary

Implement `y12mff`, a double-precision version of the iterative-refinement solver `y12mfe`. The key innovation is accurate residual accumulation in higher-than-working precision: native quad precision (`selected_real_kind(33)`) when available, otherwise a double-double compensated accumulation built on IEEE_FMA (TwoProd + TwoSum).

## Key Changes

- **New routine `src/y12mff.F90`**: Double-precision iterative refinement with two residual accumulation strategies:
  - Quad precision path: straightforward accumulation in `selected_real_kind(33)`, rounded once to double
  - Double-double path: compensated dot product (Ogita/Rump/Oishi "Dot2") using IEEE_FMA for exact products and TwoSum for exact subtraction, achieving quad-precision accuracy with only double-precision storage
  - Strategy selected at compile time via preprocessor macros `Y12M_ACCUM_QUAD` or `Y12M_ACCUM_DD`

- **CMake configuration**: Detect compiler capabilities and fix accumulator strategy:
  - Check for quad precision support (`selected_real_kind(33)`)
  - Check for IEEE_FMA (Fortran 2018) as fallback requirement
  - Apply value-safe compiler flags (`-fno-unsafe-math-optimizations`, `-fp-model=precise`, etc.) to prevent aggressive optimizations from eliminating compensation terms
  - New option `-DY12M_FORCE_DOUBLE_DOUBLE=ON` to force double-double path for reproducibility and testing

- **Module updates (`src/y12m.F90`)**:
  - Add public constants `y12mff_has_quad` (logical) and `y12mff_accum_kind` (integer kind) to expose the compiled-in accumulator strategy
  - Add interface declaration for `y12mff`

- **C bindings (`include/y12m.h`)**: Add extern declaration and inline wrapper for `y12mff`

- **Test suite (`test/test_y12mf_dp.f90`)**:
  - New test program for double-precision iterative refinement
  - Validates accumulator constants consistency
  - Tests tridiagonal (n=3,5,7,10) and arrow (n=6,10) systems with known solution x=[1,...,1]
  - Tolerance: max|x_i - 1| < 1e-13

- **Documentation and CI**:
  - Update API docs to describe both `Y12MFE` and `Y12MFF` with their accumulation strategies
  - Update README with extended-precision details and CMake configuration notes
  - Update AGENTS.md to note y12mff is hand-maintained (not template-generated)
  - Add CI job to test double-double fallback path even on quad-capable compiler

## Notable Implementation Details

- The double-double compensation terms are algebraically zero; value-unsafe floating-point modes (`-ffast-math`, `-Ofast`, ifx's `-fp-model=fast`) can eliminate them, silently degrading to plain double precision. CMake pins value-safe semantics per compiler.
- Both accumulation paths are compiled when neither macro is defined; the quad path is selected at runtime if `selected_real_kind(33) > 0`, making the code portable across build systems without preprocessing (e.g., fpm).
- The algorithm and control flow follow `y12mfe` exactly; only precision and residual accumulation differ.

https://claude.ai/code/session_014eLW6yj1t5XDeZkCmoV73o